### PR TITLE
Less hacky way of figuring out dependencies for existing views

### DIFF
--- a/lib/monocle/version.rb
+++ b/lib/monocle/version.rb
@@ -1,3 +1,3 @@
 module Monocle
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/fixtures/matview_uptodate.sql
+++ b/spec/fixtures/matview_uptodate.sql
@@ -1,4 +1,4 @@
 -- Timestamp: 2016-10-15 00:00:00 -0300
-CREATE MATERIALIZED VIEW test_matview_uptodate AS
+CREATE MATERIALIZED VIEW matview_uptodate AS
   SELECT 1
 WITH NO DATA;


### PR DESCRIPTION
- View now has a get_dependants_from_pg. Only using it for the #drop command right now but it could be useful in the future.
- You can now query if a View#exists? in the database or not
- Tests